### PR TITLE
feat: #15 enable CORS for patient dashboard

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,6 +15,10 @@ quarkus:
     ssl-port: '8443'
     insecure-requests: redirect
 
+    cors:
+      ~: true
+      origins: 'https://localhost:3000'
+
   oidc:
     auth-server-url: 'https://localhost:10443/realms/quarkus'
     client-id: 'backend-service'


### PR DESCRIPTION
Enable CORS to allow all requests from `http://localhost:3000`.